### PR TITLE
Fixed bug with linting of expected response codes

### DIFF
--- a/rest/.spectral.yaml
+++ b/rest/.spectral.yaml
@@ -270,7 +270,7 @@ rules:
         disallowDigits: false
 
 #RS400
-  operation-success-response: error
+  operation-success-response: off
   get-response-codes:
       description: RS400 - HTTP responses must return an acceptable status code
       message: "{{description}} (GETs must provide a 200 response)"
@@ -278,10 +278,10 @@ rules:
       given: $.paths[*].get.responses
       then:
         function: schema
-        functionOptions:
-          schema:
-            oneOf:
-            - required: ['200']
+      functionOptions:
+        schema:
+          anyOf:
+          - required: ['200']
 
   delete-response-codes:
     description: RS400 - HTTP responses must return an acceptable status code
@@ -292,10 +292,9 @@ rules:
       function: schema
       functionOptions:
         schema:
-          oneOf:
-          - required: ['202', '204']
-            not:
-              required: ['200', '201']
+          anyOf:
+          - required: ['202']
+          - required: ['204']
 
   put-response-codes:
     description: RS400 - HTTP responses must return an acceptable status code
@@ -306,10 +305,9 @@ rules:
       function: schema
       functionOptions:
         schema:
-          oneOf:
-          - required: ['202', '204']
-            not:
-              required: ['200', '201']
+          anyOf:
+          - required: ['202']
+          - required: ['204']
 
   post-response-codes:
     description: RS400 - HTTP responses must return an acceptable status code
@@ -320,11 +318,10 @@ rules:
       function: schema
       functionOptions:
         schema:
-          oneOf:
-          - required: ['201', '202']
-            not:
-              required: ['200', '204']
-
+          anyOf:
+          - required: ['201']
+          - required: ['202']
+          
 #RS401 - n/a
 
 #RS402 - n/a
@@ -446,12 +443,4 @@ rules:
       functionOptions:
         match: "/^https:/"
 
-#RS900
-  health-check:
-    message: RS900 - APIs should include a health check path (/healthcheck)
-    severity: warn
-    formats: ['oas2','oas3']
-    given: $.paths
-    then:
-        field: "/healthcheck"
-        function: truthy
+#RS900 - n/a


### PR DESCRIPTION
Logic was not quite on when multiple options available. Also disabled healthcheck linting due to practicality.